### PR TITLE
python-keystoneclient based plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,3 +46,22 @@ License
 -------
 
 Apache 2.0
+
+Release Notes
+=============
+
+0.1.0
+-----
+
+* Changed plugin style to match OpenStack SDK's shift to python-keystoneclient
+  styled authentication plugins.
+
+.. note:: This release is incompatible with 0.0.1. The ``user_name``
+          authentication parameter has changed to ``username``.
+
+0.0.1
+-----
+
+* Initial release
+* Support for password, API key, and token authentication
+* Support for Cloud Files Bulk Delete

--- a/rackspace/auth/identity/rackspace.py
+++ b/rackspace/auth/identity/rackspace.py
@@ -12,99 +12,74 @@
 
 """
 Rackspace authorization plugins.
-TODO
 """
 
+import abc
 import logging
 
 from openstack.auth import access
-from openstack.auth.identity import base
+from openstack.auth.identity import discoverable
+from openstack.auth.identity import v2
 from openstack import exceptions
 
 _logger = logging.getLogger(__name__)
 
 AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0/"
 
+PASSWORD_OPTIONS = [
+    "auth_url",
+    "username",
+    "api_key",
+    "password",
+    "tenant_id",
+    "project_id",
+    "tenant_name",
+    "project_name",
+    "reauthenticate",
+]
 
-class Auth(base.BaseIdentityPlugin):
+TOKEN_OPTIONS = [
+    "auth_url",
+    "token",
+    "tenant_id",
+    "project_id",
+    "tenant_name",
+    "project_name",
+    "reauthenticate",
+]
+
+
+class Discoverable(discoverable.Auth):
 
     #: Valid options for this plugin
-    valid_options = [
-        "auth_url",
-        "user_name",
-        "password",
-        "api_key",
-        "token",
-        "tenant_id",
-        "tenant_name",
-        "reauthenticate"
-    ]
+    valid_options = list(set(PASSWORD_OPTIONS + TOKEN_OPTIONS))
 
-    def __init__(self, auth_url=AUTH_URL, user_name=None, password="",
-                 api_key="", token=None, tenant_id=None, tenant_name=None,
-                 reauthenticate=True):
+    def __init__(self, auth_url=AUTH_URL, reauthenticate=True, **auth_args):
+        """Construct an Identity Authentication Plugin.
 
-        super(Auth, self).__init__(auth_url=auth_url,
-                                   reauthenticate=reauthenticate)
+        This authorization plugin should be constructed with an auth_url
+        and everything needed by either a v2 or v3 identity plugin.
 
-        if not (user_name or token):
-            msg = "You must specify either a user_name or token"
+        :param string auth_url: Identity service endpoint for authentication.
+
+        :raises TypeError: if a user_id, username or token is not provided.
+        """
+        if not auth_url:
+            msg = ("The authorization URL auth_url was not provided.")
             raise exceptions.AuthorizationFailure(msg)
 
-        if ((tenant_id and tenant_name) or
-           (token and not any([tenant_id, tenant_name]))):
-            msg = "Only one of tenant_name and tenant_id can be specified."
-            raise exceptions.AuthorizationFailure(msg)
+        self.auth_url = auth_url
+        self.access_info = None
+        self.reauthenticate = reauthenticate
 
-        self.user_name = user_name
-        self.password = password
-        self.api_key = api_key
-        self.token = token
-        self.tenant_id = tenant_id
-        self.tenant_name = tenant_name
-
-    def authorize(self, transport, **kwargs):
-        """Obtain access information from Rackspace."""
-        headers = {"Content-type": "application/json"}
-        url = self.auth_url.rstrip('/') + '/tokens'
-        params = {'auth': self.get_auth_data(headers)}
-
-        _logger.debug('Making authentication request to %s', url)
-        resp = transport.post(url, json=params, headers=headers)
-
-        try:
-            resp_data = resp.json()['access']
-        except (KeyError, ValueError):
-            raise exceptions.InvalidResponse(response=resp)
-
-        return access.AccessInfoV2(**resp_data)
-
-    def get_auth_data(self, headers):
-        """Identity v2 token authentication data."""
-        if self.token is None:
-            if self.password:
-                data = {"passwordCredentials":
-                        {"username": self.user_name,
-                         "password": self.password}}
-            elif self.api_key:
-                data = {"RAX-KSKEY:apiKeyCredentials":
-                        {"username": self.user_name, "apiKey": self.api_key}}
-
-            if self.tenant_name:
-                data["tenantName"] = self.tenant_name
-            elif self.tenant_id:
-                data["tenantId"] = self.tenant_id
-
-            return data
+        if auth_args.get('token'):
+            plugin = Token
         else:
-            data = {"token": {"id": self.token}}
+            plugin = Password
 
-            if self.tenant_id:
-                data["tenantId"] = self.tenant_id
-            elif self.tenant_name:
-                data["tenantName"] = self.tenant_name
-
-            return data
+        valid_list = plugin.valid_options
+        args = dict((n, auth_args[n]) for n in valid_list if n in auth_args)
+        self.auth_plugin = plugin(auth_url, **args)
 
     def invalidate(self):
         """Invalidate the current authentication data."""
@@ -113,3 +88,88 @@ class Auth(base.BaseIdentityPlugin):
             self.access_info = None
             return True
         return False
+
+
+class Password(v2.Auth):
+
+    #: Valid options for Password plugin
+    valid_options = PASSWORD_OPTIONS
+
+    def __init__(self, auth_url=AUTH_URL, username=None, password="",
+                 api_key="", **kwargs):
+        """A plugin for authenticating with a user_name and password.
+
+        A user_name or user_id must be provided.
+
+        :param string auth_url: Identity service endpoint for authorization.
+                                This defaults to AUTH_URL
+        :param string username: Username for authentication
+        :param string password: Password for authentication
+        :param string api_key: API Key for authentication
+        :param string tenant_id: Tenant ID for tenant scoping
+        :param string tenant_name: Tenant name for tenant scoping
+        :param bool reauthenticate: Allow fetching a new token if the
+                                    current one is going to expire.
+                                    (optional) default True
+
+        :raises: ValueError if the username is ``None`` or if both a
+                 ``tenant_name`` and ``tenant_id`` are specified.
+        """
+        super(Password, self).__init__(auth_url=auth_url, **kwargs)
+
+        if username is None:
+            raise ValueError("You must specify a username")
+
+        self.username = username
+        self.password = password
+        self.api_key = api_key
+
+    def get_auth_data(self, headers=None):
+        """Identity v2 token authentication data."""
+
+        if self.password:
+            return {"passwordCredentials": {
+                    "username": self.username, "password": self.password}}
+        elif self.api_key:
+             return {"RAX-KSKEY:apiKeyCredentials": {
+                     "username": self.username, "apiKey": self.api_key}}
+
+
+class Token(v2.Auth):
+
+    #: Valid options for Token plugin
+    valid_options = TOKEN_OPTIONS
+
+    def __init__(self, auth_url=AUTH_URL, token=None, **kwargs):
+        """A plugin for authenticating with an existing token.
+
+        :param string auth_url: Identity service endpoint for authorization.
+        :param string token: Existing token for authentication.
+        :param string tenant_id: Tenant ID for tenant scoping.
+        :param string tenant_name: Tenant name for tenant scoping.
+        :param bool reauthenticate: Allow fetching a new token if the current
+                                    one is going to expire.
+                                    (optional) default True
+        """
+        super(Token, self).__init__(auth_url=auth_url, **kwargs)
+
+        if token is None:
+            raise Exception("You must specify a token")
+
+        if all([tenant_name, tenant_id]):
+            raise ValueError(
+                "You cannot specify both a tenant_name and tenant_id")
+
+        self.tenant_id = tenant_id
+        self.tenant_name = tenant_name
+        self.token = token
+
+    def get_auth_data(self, headers=None):
+        data = {"token": {"id": self.token}}
+
+        if self.tenant_id:
+            data["tenantId"] = self.tenant_id
+        elif self.tenant_name:
+            data["tenantName"] = self.tenant_name
+
+        return data

--- a/rackspace/tests/auth/identity/test_rackspace.py
+++ b/rackspace/tests/auth/identity/test_rackspace.py
@@ -26,12 +26,12 @@ class TestRackspaceAuth(testtools.TestCase):
     def test_password(self):
         kargs = {
             "password": common.TEST_PASS,
-            "user_name": common.TEST_USER,
+            "username": common.TEST_USER,
         }
 
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Password(**kargs)
 
-        self.assertEqual(common.TEST_USER, sot.user_name)
+        self.assertEqual(common.TEST_USER, sot.username)
         self.assertEqual(common.TEST_PASS, sot.password)
         expected = {"passwordCredentials": {"password": common.TEST_PASS,
                                             "username": common.TEST_USER}}
@@ -42,12 +42,12 @@ class TestRackspaceAuth(testtools.TestCase):
     def test_api_key(self):
         kargs = {
             "api_key": common.TEST_PASS,
-            "user_name": common.TEST_USER,
+            "username": common.TEST_USER,
         }
 
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Password(**kargs)
 
-        self.assertEqual(common.TEST_USER, sot.user_name)
+        self.assertEqual(common.TEST_USER, sot.username)
         self.assertEqual(common.TEST_PASS, sot.api_key)
         expected = {"RAX-KSKEY:apiKeyCredentials":
                     {"apiKey": common.TEST_PASS,
@@ -63,7 +63,7 @@ class TestRackspaceAuth(testtools.TestCase):
         }
 
         with testtools.ExpectedException(exceptions.AuthorizationFailure):
-            rackspace.Auth(**kargs)
+            rackspace.Token(**kargs)
 
     def test_token_with_tenant_id(self):
         kargs = {
@@ -86,7 +86,7 @@ class TestRackspaceAuth(testtools.TestCase):
         self.assertEqual(common.TEST_TENANT_NAME, sot.tenant_name)
 
     def _test_token(self, kargs, expected):
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Token(**kargs)
 
         self.assertEqual(common.TEST_TOKEN, sot.token)
         headers = {}
@@ -107,13 +107,13 @@ class TestRackspaceAuth(testtools.TestCase):
             "tenant_id": common.TEST_TENANT_ID,
             "token": common.TEST_TOKEN,
         }
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Token(**kargs)
         xport = self.create_mock_transport(TEST_RESPONSE_DICT)
 
         resp = sot.authorize(xport)
 
         eurl = rackspace.AUTH_URL.rstrip("/") + "/tokens"
-        eheaders = {"Content-type": "application/json"}
+        eheaders = {"Accept": "application/json"}
         ejson = {"auth": {"token": {"id": common.TEST_TOKEN},
                           "tenantId": common.TEST_TENANT_ID}}
         xport.post.assert_called_with(eurl, headers=eheaders, json=ejson)
@@ -126,13 +126,13 @@ class TestRackspaceAuth(testtools.TestCase):
             "tenant_name": common.TEST_TENANT_NAME,
             "token": common.TEST_TOKEN,
         }
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Token(**kargs)
         xport = self.create_mock_transport(TEST_RESPONSE_DICT)
 
         resp = sot.authorize(xport)
 
         eurl = rackspace.AUTH_URL.rstrip("/") + "/tokens"
-        eheaders = {"Content-type": "application/json"}
+        eheaders = {"Accept": "application/json"}
         ejson = {"auth": {"token": {"id": common.TEST_TOKEN},
                           "tenantName": common.TEST_TENANT_NAME}}
         xport.post.assert_called_with(eurl, headers=eheaders, json=ejson)
@@ -145,7 +145,7 @@ class TestRackspaceAuth(testtools.TestCase):
             "token": common.TEST_TOKEN,
             "tenant_name": common.TEST_TENANT_NAME
         }
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Token(**kargs)
         xport = self.create_mock_transport({})
 
         with testtools.ExpectedException(exceptions.InvalidResponse):
@@ -156,7 +156,7 @@ class TestRackspaceAuth(testtools.TestCase):
             "token": common.TEST_TOKEN,
             "tenant_name": common.TEST_TENANT_NAME,
         }
-        sot = rackspace.Auth(**kargs)
+        sot = rackspace.Token(**kargs)
         expected = {"tenantName": common.TEST_TENANT_NAME,
                     "token": {"id": common.TEST_TOKEN}}
         headers = {}
@@ -166,16 +166,3 @@ class TestRackspaceAuth(testtools.TestCase):
 
         self.assertEqual(None, sot.token)
         self.assertEqual(None, sot.access_info)
-
-    def test_valid_options(self):
-        expected = [
-            "auth_url",
-            "user_name",
-            "password",
-            "api_key",
-            "token",
-            "tenant_id",
-            "tenant_name",
-            "reauthenticate"
-        ]
-        self.assertEqual(expected, rackspace.Auth.valid_options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-python-openstacksdk>=0.3
+six
+python-openstacksdk>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = rackspace-sdk-plugin
-version = 0.0.1
+version = 0.1.0
 summary = Rackspace plugin for the OpenStack SDK
 description-file =
     README.rst
@@ -30,4 +30,6 @@ universal = 1
 
 [entry_points]
 openstack.auth.plugin =
-    rackspace = rackspace.auth.identity.rackspace:Auth
+    rackspace_token = rackspace.auth.identity.rackspace:Token
+    rackspace_password = rackspace.auth.identity.rackspace:Password
+    rackspace = rackspace.auth.identity.rackspace:Discoverable


### PR DESCRIPTION
OpenStack SDK made a planned move to revert to the style of plugins used by python-keystoneclient, in an effort to track that style of plugins as they're being implemented and used elsewhere.