### PR TITLE
Update for 0.6.2

### DIFF
--- a/rackspace/connection.py
+++ b/rackspace/connection.py
@@ -16,8 +16,7 @@ from openstack import profile as _profile
 
 class Connection(connection.Connection):
 
-    def __init__(self, region=None, auth_plugin="rackspace", profile=None,
-                 **kwargs):
+    def __init__(self, region=None, profile=None, **kwargs):
         """Create a connection to the Rackspace Public Cloud
 
         This is a subclass of :class:`openstack.connection.Connection` that
@@ -31,13 +30,13 @@ class Connection(connection.Connection):
         :raises: ValueError if no `region` is specified.
         """
         if profile is None:
-            profile = _profile.Profile(extensions=["rackspace"])
+            profile = _profile.Profile(plugins=["rackspace"])
 
         if region is None:
             raise ValueError("You must specify a region to work with.")
 
         profile.set_region(profile.ALL, region)
 
-        super(Connection, self).__init__(auth_plugin=auth_plugin,
+        super(Connection, self).__init__(auth_plugin="rackspace",
                                          profile=profile,
                                          **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-openstacksdk>=0.6
+openstacksdk>=0.6.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = rackspace-sdk-plugin
+name = rackspacesdk
 summary = Rackspace plugin for the OpenStack SDK
 description-file =
     README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ name = rackspacesdk
 summary = Rackspace plugin for the OpenStack SDK
 description-file =
     README.rst
-    ChangeLog
 author = Rackspace
 author-email = sdk-support@rackspace.com
 home-page = https://developer.rackspace.org/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = rackspace-sdk-plugin
-version = 0.3.1
 summary = Rackspace plugin for the OpenStack SDK
 description-file =
     README.rst


### PR DESCRIPTION
This change updates the plugin to work with changes made to OpenStack SDK 0.6.2

The main change is that the Connection class now takes `plugins` instead of `extensions`.

Two setup changes were made: no explicit version is set because pbr handles that based on tags, and the package name was updated from rackspace-sdk-plugin to rackspacesdk.