### PR TITLE
Silence warning about certificate

### DIFF
--- a/rackspace/auth/identity/rackspace.py
+++ b/rackspace/auth/identity/rackspace.py
@@ -16,6 +16,17 @@ Rackspace authorization plugins.
 
 import logging
 
+# NOTE: The following two lines disable warning messages coming out of the
+# urllib3 that is vendored by requests. This is currently necessary to
+# silence a warning about an issue with the certificate in our identity
+# environment. The certificate is missing a subjectAltName, and urllib3
+# is warning that the fallback to check the commonName is something that is
+# soon to be unsupported. The Rackspace Identity team has been working on
+# a solution to this issue, and the environment is slated to be upgraded
+# by end of year 2015.
+import requests
+requests.packages.urllib3.disable_warnings()
+
 from openstack.auth.identity import discoverable
 from openstack.auth.identity import v2
 from openstack import exceptions


### PR DESCRIPTION
The certificate in our current identity environment lacks a subjectAltName, causing a fallback to check the commonName. This is soon to be unsupported, thus raising a SecurityWarning. As this is purely a warning and there is no current security issue, we are silencing it. Note that the warning is only silenced when coming from the urllib3 that is included with requests, meaning we're not blanket silencing anything.