### PR TITLE
connection: don't set region in profiles created by the caller

### DIFF
--- a/rackspace/connection.py
+++ b/rackspace/connection.py
@@ -17,7 +17,7 @@ from rackspaceauth import v2
 
 class Connection(connection.Connection):
 
-    def __init__(self, region=None, profile=None, **kwargs):
+    def __init__(self, profile=None, **kwargs):
         """Create a connection to the Rackspace Public Cloud
 
         This is a subclass of :class:`openstack.connection.Connection` that
@@ -31,19 +31,7 @@ class Connection(connection.Connection):
         :raises: ValueError if no `region` is specified.
         """
         if profile is None:
-            profile = _profile.Profile(plugins=["rackspace"])
-
-        if region is None:
-            raise ValueError("You must specify a region to work with.")
-
-        profile.set_region(profile.ALL, region)
-
-        global_services = ('cloudMetrics', 'cloudMetricsIngest',
-                           'cloudMonitoring', 'rackCDN')
-
-        for service in profile.get_services():
-            if service.service_name in global_services:
-                service.region = None
+            profile = self._create_profile(**kwargs)
 
         username = kwargs.pop("username", None)
         tenant_id = kwargs.pop("tenant_id", None)
@@ -70,3 +58,20 @@ class Connection(connection.Connection):
         super(Connection, self).__init__(authenticator=auth,
                                          profile=profile,
                                          **kwargs)
+
+    def _create_profile(self, region=None, **kwargs):
+        profile = _profile.Profile(plugins=["rackspace"])
+
+        if region is None:
+            raise ValueError("You must specify a region to work with.")
+
+        profile.set_region(profile.ALL, region)
+
+        global_services = ('cloudMetrics', 'cloudMetricsIngest',
+                           'cloudMonitoring', 'rackCDN')
+
+        for service in profile.get_services():
+            if service.service_name in global_services:
+                service.region = None
+
+        return profile

--- a/rackspace/connection.py
+++ b/rackspace/connection.py
@@ -11,13 +11,14 @@
 # under the License.
 
 from openstack import connection
-from openstack import profile as _profile
 from rackspaceauth import v2
+
+from rackspace import profile as _profile
 
 
 class Connection(connection.Connection):
 
-    def __init__(self, profile=None, **kwargs):
+    def __init__(self, region, profile=None, **kwargs):
         """Create a connection to the Rackspace Public Cloud
 
         This is a subclass of :class:`openstack.connection.Connection` that
@@ -31,7 +32,7 @@ class Connection(connection.Connection):
         :raises: ValueError if no `region` is specified.
         """
         if profile is None:
-            profile = self._create_profile(**kwargs)
+            profile = _profile.Profile(region=region, **kwargs)
 
         username = kwargs.pop("username", None)
         tenant_id = kwargs.pop("tenant_id", None)
@@ -58,20 +59,3 @@ class Connection(connection.Connection):
         super(Connection, self).__init__(authenticator=auth,
                                          profile=profile,
                                          **kwargs)
-
-    def _create_profile(self, region=None, **kwargs):
-        profile = _profile.Profile(plugins=["rackspace"])
-
-        if region is None:
-            raise ValueError("You must specify a region to work with.")
-
-        profile.set_region(profile.ALL, region)
-
-        global_services = ('cloudMetrics', 'cloudMetricsIngest',
-                           'cloudMonitoring', 'rackCDN')
-
-        for service in profile.get_services():
-            if service.service_name in global_services:
-                service.region = None
-
-        return profile

--- a/rackspace/profile.py
+++ b/rackspace/profile.py
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack import profile
+
+
+class Profile(profile.Profile):
+
+    def __init__(self, region, plugins=None, **kwargs):
+        super(Profile, self).__init__(plugins=plugins or ['rackspace'])
+
+        self.set_region(self.ALL, region)
+
+        global_services = ('cloudMetrics', 'cloudMetricsIngest',
+                           'cloudMonitoring', 'rackCDN')
+
+        for service in self.get_services():
+            if service.service_name in global_services:
+                service.region = None

--- a/rackspace/tests/unit/test_connection.py
+++ b/rackspace/tests/unit/test_connection.py
@@ -13,6 +13,7 @@
 import mock
 import unittest2
 
+from openstack import profile
 from rackspace import connection
 
 
@@ -22,16 +23,14 @@ class TestConnection(unittest2.TestCase):
         with self.assertRaises(ValueError):
             connection.Connection()
 
-    @mock.patch("rackspace.connection.Connection._open")
-    def test_with_region(self, mock_open=lambda: None):
-        prof = mock.Mock()
-        prof.get_services = mock.Mock(return_value=list())
+    @mock.patch.object(profile.Profile, 'set_region')
+    def test_with_region(self, mock_set_region):
         region = "BEN"
 
-        connection.Connection(region=region, profile=prof,
+        connection.Connection(region=region,
                               username="test", api_key="test")
 
-        prof.set_region.assert_called_with(prof.ALL, region)
+        mock_set_region.assert_called_with(profile.Profile.ALL, region)
 
     @mock.patch("rackspaceauth.v2.APIKey")
     def test_auth_with_APIKey(self, mock_apikey):

--- a/rackspace/tests/unit/test_connection.py
+++ b/rackspace/tests/unit/test_connection.py
@@ -19,10 +19,6 @@ from rackspace import connection
 
 class TestConnection(unittest2.TestCase):
 
-    def test_no_region(self):
-        with self.assertRaises(TypeError):
-            connection.Connection()
-
     @mock.patch.object(profile.Profile, 'set_region')
     def test_with_region(self, mock_set_region):
         region = "BEN"

--- a/rackspace/tests/unit/test_connection.py
+++ b/rackspace/tests/unit/test_connection.py
@@ -20,7 +20,7 @@ from rackspace import connection
 class TestConnection(unittest2.TestCase):
 
     def test_no_region(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             connection.Connection()
 
     @mock.patch.object(profile.Profile, 'set_region')


### PR DESCRIPTION
It should be the caller's responsibility to handle this, if they are passing a custom profile.