### PR TITLE
Add configuration property to HA instance

### DIFF
--- a/rackspace/database/v1/high_availability_instance.py
+++ b/rackspace/database/v1/high_availability_instance.py
@@ -54,7 +54,7 @@ class HighAvailabilityInstance(resource.Resource):
     #: Volumes. *Type: dict*
     volume = resource.prop('volume', type=dict)
     #: The configuration ID for this instance. *Type: string*
-    configuration = resource.prop('configuration')
+    configuration_id = resource.prop('configuration')
 
     def add_acl(self, session, cidr):
         """Add Access Control List (ACL)

--- a/rackspace/database/v1/high_availability_instance.py
+++ b/rackspace/database/v1/high_availability_instance.py
@@ -53,6 +53,8 @@ class HighAvailabilityInstance(resource.Resource):
     status = resource.prop('state')
     #: Volumes. *Type: dict*
     volume = resource.prop('volume', type=dict)
+    #: The configuration ID for this instance. *Type: string*
+    configuration = resource.prop('configuration')
 
     def add_acl(self, session, cidr):
         """Add Access Control List (ACL)

--- a/rackspace/tests/unit/database/v1/test_high_availability_instance.py
+++ b/rackspace/tests/unit/database/v1/test_high_availability_instance.py
@@ -45,7 +45,7 @@ EXAMPLE = {
         "flavorRef": FLAVOR_REFERENCE,
         "name": "Tyrell"}
     ],
-    "configuration": CONFIG_UUID
+    "configuration_id": CONFIG_UUID
 }
 
 
@@ -71,7 +71,7 @@ class TestHA(testtools.TestCase):
         self.assertEqual(EXAMPLE['networks'], sot.networks)
         self.assertEqual(EXAMPLE['replicas'], sot.replicas)
         self.assertEqual(EXAMPLE['replica_source'], sot.replica_source)
-        self.assertEqual(EXAMPLE['configuration'], sot.configuration)
+        self.assertEqual(EXAMPLE['configuration_id'], sot.configuration_id)
 
     def test_add_acl(self):
         response = mock.Mock()

--- a/rackspace/tests/unit/database/v1/test_high_availability_instance.py
+++ b/rackspace/tests/unit/database/v1/test_high_availability_instance.py
@@ -18,6 +18,7 @@ from rackspace.database.v1 import high_availability_instance
 CIDR = '5.6.7.8/9'
 REPLICA_NAME = 'Roy Batty'
 UUID = 'xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx'
+CONFIG_UUID = 'yyyyyyyy-yyyy-Myyy-Nyyy-yyyyyyyyyyyy'
 FLAVOR_REFERENCE = '2'
 VOLUME_SIZE = 1
 
@@ -43,7 +44,8 @@ EXAMPLE = {
             "size": VOLUME_SIZE},
         "flavorRef": FLAVOR_REFERENCE,
         "name": "Tyrell"}
-    ]
+    ],
+    "configuration": CONFIG_UUID
 }
 
 
@@ -69,6 +71,7 @@ class TestHA(testtools.TestCase):
         self.assertEqual(EXAMPLE['networks'], sot.networks)
         self.assertEqual(EXAMPLE['replicas'], sot.replicas)
         self.assertEqual(EXAMPLE['replica_source'], sot.replica_source)
+        self.assertEqual(EXAMPLE['configuration'], sot.configuration)
 
     def test_add_acl(self):
         response = mock.Mock()

--- a/rackspace/tests/unit/load_balancer/v1/test_load_balancer.py
+++ b/rackspace/tests/unit/load_balancer/v1/test_load_balancer.py
@@ -54,7 +54,8 @@ class TestLoadBalancer(testtools.TestCase):
         self.assertTrue(sot.allow_create)
         self.assertTrue(sot.allow_list)
 
-        self.assertDictEqual({"status": "status",
+        self.assertDictEqual({"status": "status", "limit": "limit",
+                              "marker": "marker",
                               "node_address": "nodeaddress",
                               "changes_since": "changes-since"},
                              sot._query_mapping._mapping)


### PR DESCRIPTION
In the docs it lists `configuration` as a property in the create operation:

https://developer.rackspace.com/docs/cloud-databases/v1/api-reference/ha/#create-ha-database-instance

Context: I'm shifting some of our Ansible modules from pyrax to Rackspace SDK and we currently use configuration groups so need feature parity.