### PR TITLE
Set default version for cloud databases.

### DIFF
--- a/rackspace/database/database_service.py
+++ b/rackspace/database/database_service.py
@@ -21,6 +21,9 @@ class DatabaseService(service_filter.ServiceFilter):
     def __init__(self, version=None):
         """Create a database service."""
 
+        if not version:
+            version = "v1"
+
         super(DatabaseService, self).__init__(service_type="rax:database",
                                               service_name="cloudDatabases",
                                               version=version)


### PR DESCRIPTION
Seems like openstacksdk may require a version, but it's not getting set via rax auth catalog for cloud databases. The only way I was able to make cloud databases work via rackspacesdk was to force the version to v1 (the only version cloud databases offers today).

FWIW I was able to successfully list backups with this change as well, so it may resolve issue https://github.com/rackerlabs/rackspace-sdk-plugin/issues/20

# Code example to demonstrate the error
```
import sys

from openstack import utils
from rackspace import connection


conn = connection.Connection(username="secret",
                             api_key="secret",
                             region="IAD")


utils.enable_logging(True, stream=sys.stdout)


for instance in conn.database.instances():
    print(instance)
```

# ERROR
```
2017-11-28 10:18:25,539 DEBUG: keystoneauth.identity.v2 Making authentication request to https://identity.api.rackspacecloud.com/v2.0/tokens
2017-11-28 10:18:25,905 DEBUG: openstack.session Looking for versions at https://iad.databases.api.rackspacecloud.com
2017-11-28 10:18:25,906 DEBUG: keystoneauth.session REQ: curl -g -i -X GET https://iad.databases.api.rackspacecloud.com -H "X-Auth-Token: {SHA1}secret" -H "User-Agent: openstacksdk/0.9.19 keystoneauth1/3.2.0 python-requests/2.18.4 CPython/3.6.1"
2017-11-28 10:18:26,254 DEBUG: keystoneauth.session RESP: [200] Content-Type: application/json Via: 1.1 Repose (Repose/2.12) Content-Length: 196 Date: Tue, 28 Nov 2017 16:18:26 GMT Connection: close Server: Jetty(8.0.y.z-SNAPSHOT)
RESP BODY: {"versions": [{"status": "CURRENT", "release": "2.76.0", "updated": "2012-08-01T00:00:00Z", "id": "v1.0", "links": [{"href": "http://iad.databases.api.rackspacecloud.com/v1.0/", "rel": "self"}]}]}

Traceback (most recent call last):
  File "cloud_servers_test.py", line 40, in <module>
    list_cloud_database_instances(conn)
  File "cloud_servers_test.py", line 33, in list_cloud_database_instances
    for instance in conn.database.instances():
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/openstack/resource2.py", line 730, in list
    params=query_params)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/keystoneauth1/session.py", line 840, in get
    return self.request(url, 'GET', **kwargs)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/openstack/session.py", line 64, in map_exceptions_wrapper
    return func(*args, **kwargs)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/openstack/session.py", line 352, in request
    return super(Session, self).request(*args, **kwargs)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/keystoneauth1/session.py", line 595, in request
    **endpoint_filter)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/openstack/session.py", line 340, in get_endpoint
    profile_version = self._parse_version(filt.version)
  File "/Users/xyz/virtualenvs/raxcloudtest/lib/python3.6/site-packages/openstack/session.py", line 240, in _parse_version
    version_num = version[version.find("v") + 1:]
AttributeError: 'NoneType' object has no attribute 'find'```